### PR TITLE
escape special char in xml, which will cause bad request (faultstring) from marketo

### DIFF
--- a/marketo/wrapper/sync_lead.py
+++ b/marketo/wrapper/sync_lead.py
@@ -1,5 +1,6 @@
 
 import xml.etree.ElementTree as ET
+from xml.sax.saxutils import escape
 import lead_record
 
 
@@ -9,7 +10,7 @@ def wrap(email=None, attributes=None):
         attr += '<attribute>' \
             '<attrName>' + i[0] + '</attrName>' \
             '<attrType>' + i[1] + '</attrType>' \
-            '<attrValue>' + i[2] + '</attrValue>' \
+            '<attrValue>' + escape(i[2]) + '</attrValue>' \
             '</attribute>'
 
     return(


### PR DESCRIPTION
When sending data with special character(&, <, >) in the value, marketo return bad request, fixed by escape these characters.
